### PR TITLE
Feature/delete expired reservations middleware

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -68,5 +68,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'deleteExpiredReservations' => \App\Http\Middleware\DeleteExpiredReservationsMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/DeleteExpiredReservationsMiddleware.php
+++ b/app/Http/Middleware/DeleteExpiredReservationsMiddleware.php
@@ -5,7 +5,6 @@ namespace App\Http\Middleware;
 use App\Models\Reservation;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 class DeleteExpiredReservationsMiddleware
@@ -18,8 +17,7 @@ class DeleteExpiredReservationsMiddleware
     public function handle(Request $request, Closure $next): Response
     {
         $today = date('Y-m-d');
-        $result = Reservation::where('start_at', '<', $today)->delete();
-        Log::debug($result);
+        Reservation::where('start_at', '<', $today)->delete();
         return $next($request);
     }
 }

--- a/app/Http/Middleware/DeleteExpiredReservationsMiddleware.php
+++ b/app/Http/Middleware/DeleteExpiredReservationsMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Reservation;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteExpiredReservationsMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $today = date('Y-m-d');
+        $result = Reservation::where('start_at', '<', $today)->delete();
+        Log::debug($result);
+        return $next($request);
+    }
+}

--- a/resources/views/books/index.blade.php
+++ b/resources/views/books/index.blade.php
@@ -15,7 +15,7 @@
         <li class="li" >
             <img src="{{ 'storage/'. $book->image_path}}" style='max-width:300px;max-height:500px'>
             <br>
-            <a href="{{ route('books.show', ['bookId'=> $book->id])}}">{{ $book->title }}
+            <a href="{{ route('books.show', ['bookId'=> $book->id])}}">{{ $book->title }} </a>
         </li>
     @endforeach
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,7 +44,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/lendings/{lendingId}', [LendingController::class, 'show'])->name('lendings.show');
 });
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'deleteExpiredReservations'])->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index'])->name('reservations.index');
     Route::get('/reservations/{reservationId}', [ReservationController::class, 'show'])->name('reservations.show');
     Route::post('/reservations', [ReservationController::class, 'store'])->name('reservations.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,4 +50,5 @@ Route::middleware(['auth', 'deleteExpiredReservations'])->group(function () {
     Route::post('/reservations', [ReservationController::class, 'store'])->name('reservations.store');
     Route::delete('/reservations/{reservationId}', [ReservationController::class, 'destroy'])->name('reservations.destroy');
 });
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
予約開始日が過ぎたデータを削除するミドルウェアを実装
reserationsのルーティングのみに適応


関連する問題やタスク:
現在'auth'ミドルウェアは、個別のミドルウェアグループに指定されている。
'delete expired reservations middleware'と一緒にルート全体に適用するために、コードを整理する必要がある