### PR TITLE
Feature/validate reservation overlap

### DIFF
--- a/app/Http/Requests/StoreReservationRequest.php
+++ b/app/Http/Requests/StoreReservationRequest.php
@@ -3,12 +3,14 @@
 namespace App\Http\Requests;
 
 use App\Models\Reservation;
+use App\Rules\OverlapReservation;
 use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
 class StoreReservationRequest extends FormRequest
 {
+    // protected $stopOnFirstFailure = true;
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -27,7 +29,8 @@ class StoreReservationRequest extends FormRequest
         return [
             'book_id'  => 'required',
             'start_at' => 'required|date|after_or_equal:today',
-            'end_at'   => 'required|date|after_or_equal:start_at|before_or_equal:' . $this->getEndDateLimit(),
+            'end_at'   => ['required','date','after_or_equal:start_at', new OverlapReservation(),
+                           'before_or_equal:' . $this->getEndDateLimit()],
         ];
     }
 
@@ -35,27 +38,33 @@ class StoreReservationRequest extends FormRequest
     {
         //終了日を開始日から7日以内とするためのメソッド
         $startDate = Carbon::parse($this->input('start_at'));
-        return $startDate->copy()->addDays(7)->format('Y-m-d');
+        return  is_null($this->input('start_at'))? 'end_at' : $startDate->copy()->addDays(7)->format('Y-m-d');
     }
 
-    public function after(): array
-    {
-        $book_id  = $this->request->get('book_id');
-        $start_at = $this->request->get('start_at');
-        $end_at   = $this->request->get('end_at');
-        $isReservationExists = Reservation::where('book_id', $book_id)
-                           ->whereHasReservation($start_at, $end_at)
-                           ->exists();
-
-        return [
-            function (Validator $validator) use($isReservationExists) {
-                if ($isReservationExists) {
-                    $validator->errors()->add(
-                        'date_range',
-                        'すでに予約が入っています。他の日付を選択してください。'
-                    );
-                }
-            }
-        ];
-    }
+    // public function after(): array
+    // {
+    //     $book_id  = $this->request->get('book_id');
+    //     $start_at = $this->request->get('start_at');
+    //     $end_at   = $this->request->get('end_at');
+    //
+    //     if (($start_at && $end_at) && $start_at<=$end_at){
+    //         $isReservationExists = Reservation::where('book_id', $book_id)
+    //             ->whereHasReservation($start_at, $end_at)
+    //             ->exists();
+    //     }else{
+    //         $isReservationExists = false;
+    //     }
+    //
+    //
+    //     return [
+    //         function (Validator $validator) use($isReservationExists) {
+    //             if ($isReservationExists) {
+    //                 $validator->errors()->add(
+    //                     'date_range',
+    //                     'すでに予約が入っています。他の日付を選択してください。'
+    //                 );
+    //             }
+    //         }
+    //     ];
+    // }
 }

--- a/app/Models/Reservation.php
+++ b/app/Models/Reservation.php
@@ -37,7 +37,7 @@ class Reservation extends Model
         })
             ->orWhere(function ($q) use ($start, $end) {
                 //チェックしたい日付の中で終わる予約がある
-                $q->where('end_at', '>', $start)
+                $q->where('end_at', '>=', $start)
                     ->where('end_at', '<=', $end);
             })
             ->orWhere(function ($q) use ($start, $end) {

--- a/app/Rules/OverlapReservation.php
+++ b/app/Rules/OverlapReservation.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\Reservation;
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class OverlapReservation implements DataAwareRule, ValidationRule
+{
+    protected $data = [];
+
+    /**
+     * Run the validation rule.
+     *
+     * @param \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail) : void
+    {
+        $book_id  = $this->data['book_id'];
+        $start_at = $this->data['start_at'];
+        $end_at   = $this->data['end_at'];
+
+        if (($start_at && $end_at) && $start_at <= $end_at) {
+            $isReservationExists = Reservation::where('book_id', $book_id)
+                ->whereHasReservation($start_at, $end_at)
+                ->exists();
+        } else {
+            $isReservationExists = false;
+        }
+        if ($isReservationExists) {
+            $fail('すでに予約が入っています。他の日付を選択してください。');
+        }
+    }
+
+    public function setData(array $data) : static
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
make:rule でOverlapReservation.phpを作成し、
予約が重複しているかどうかの確認処理を実行。



<h2>備考</h2>
public function after(): で同様の処理を実行しているが、コメントアウトしています。
どちらを使うか決めたら修正予定

start_at 、end_atの入力がない場合、Reservationモデル内のscopeWhereHasReservation内でエラーが発生していたが
その場合は if 文でエラーの表示がでないように修正　
　$isReservationExists = false;

<h2>Reservationモデル内のscopeWhereHasReservation修正</h2>
予約の終了日と開始日が同じにならないように等符号を追加
※画像は修正前
<img width="345" alt="Screen Shot 2023-05-30 at 16 55 55" src="https://github.com/shunjuio/laravel_books_app/assets/119388442/3ed2936a-9312-4b38-a91d-fde6130bfaed">
